### PR TITLE
[WIP] Updated SDK version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,25 @@
-FROM anapsix/alpine-java:8_jdk
+FROM gradle:4.8.1-jdk8-alpine
 
 MAINTAINER Can Kutlu Kinay <me@ckk.im>
 
-ENV SDK_VERSION     25.2.3
-ENV SDK_CHECKSUM    1b35bcb94e9a686dff6460c8bca903aa0281c6696001067f34ec00093145b560
+USER root
 ENV ANDROID_HOME    /opt/android-sdk
-ENV SDK_UPDATE      tools,platform-tools,build-tools-25.0.2,android-25,android-24,android-23,android-22,android-21,sys-img-armeabi-v7a-android-23,sys-img-x86-android-23
-ENV LD_LIBRARY_PATH ${ANDROID_HOME}/tools/lib64/qt:${ANDROID_HOME}/tools/lib/libQt5:$LD_LIBRARY_PATH/
-ENV GRADLE_VERSION  2.13
-ENV GRADLE_HOME     /opt/gradle-${GRADLE_VERSION}
-ENV PATH            ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${GRADLE_HOME}/bin
-
-RUN apk add --no-cache curl \
-    && curl -SLO "https://dl.google.com/android/repository/tools_r${SDK_VERSION}-linux.zip" \
-    && echo "${SDK_CHECKSUM}  tools_r${SDK_VERSION}-linux.zip" | sha256sum -cs \
+ENV SDK_VERSION     4333796
+ENV SDK_CHECKSUM    92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
+ENV SDK_UPDATE      "tools platform-tools build-tools;28.0.1 \
+                    platforms;android-27 platforms;android-26 platforms;android-25 \
+                    platforms;android-24 platforms;android-23 platforms;android-22 \
+                    platforms;android-21 platforms;android-20"
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache curl bash \
+    && curl -SLO "https://dl.google.com/android/repository/sdk-tools-linux-${SDK_VERSION}.zip" \
+    && echo "${SDK_CHECKSUM}  sdk-tools-linux-${SDK_VERSION}.zip" | sha256sum -cs \
     && mkdir -p "${ANDROID_HOME}" \
-    && unzip "tools_r${SDK_VERSION}-linux.zip" -d "${ANDROID_HOME}" \
-    && rm -Rf "tools_r${SDK_VERSION}-linux.zip" \
-    && echo y | ${ANDROID_HOME}/tools/android update sdk --filter ${SDK_UPDATE} --all --no-ui --force \
+    && unzip "sdk-tools-linux-${SDK_VERSION}.zip" -d "${ANDROID_HOME}" \
+    && rm -Rf "sdk-tools-linux-${SDK_VERSION}.zip" \
+    && echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager ${SDK_UPDATE} \
     && mkdir -p ${ANDROID_HOME}/tools/keymaps \
     && touch ${ANDROID_HOME}/tools/keymaps/en-us \
-    # Licenses taken from https://github.com/mindrunner/docker-android-sdk
-    && mkdir -p ${ANDROID_HOME}/licenses \
-    && echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\n" > ${ANDROID_HOME}/licenses/android-sdk-license \
-    && echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd\n" > ${ANDROID_HOME}/licenses/android-sdk-preview-license \
-    # Install gradle
-    && curl -SLO https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
-    && mkdir -p "${GRADLE_HOME}" \
-    && unzip "gradle-${GRADLE_VERSION}-bin.zip" -d "/opt" \
-    && rm -f "gradle-${GRADLE_VERSION}-bin.zip" \
     && apk del curl

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This image provides Android SDK with Oracle Java. Includes gradle binaries.
 
-## Supported tags and respective `Dockerfile` links
+## Build image
+```sh
+docker build -t docker-alpine-android-sdk:28 -t docker-alpine-android-sdk:latest .
+```
 
-* `25.2.3`, `25`, `latest` [(25/Dockerfile)](https://github.com/cakuki/docker-alpine-android-sdk/blob/25_2_3/Dockerfile)
+## Supported tags
+
+* `28`, `latest`


### PR DESCRIPTION
**This is broken still, I forgot about glibc -- will fix asap** 
Hi,
I found this useful even though it didnt work out of box, but I have fixed that now.
I did take some liberties here, I did replaced the docker image with a gradle one instead. I use it this way for my android build bot. 

If you have suggestions on how it perhaps can be more versatile or usable please let me know and I will fix it.

### NOTE
* `master` branch in current state does not work, google changed URLs and packaging format for the sdk builds.

### CHANGES

* Switched docker image to `gradle:4.8.1-jdk8-alpine`

Kind regards,
Niclas